### PR TITLE
Error handling

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -53,22 +53,17 @@ router.post('/*', async (req, res) => {
     }
   }
 
-  let result;
   try {
-    result = await graphqlQuery(url, str);
-    if (result.errors) {
-      return subgraphError(res, null, result.errors);
-    }
+    const result = await graphqlQuery(url, str);
+    if (result.errors) return res.status(500).json(result);
+    if (result?.data && caching) set(key, result).then(() => console.log('Cache stored', { key }));
+
+    return res.json(result);
   } catch (error: any) {
+    // in cases like network error or text response
     console.log(`subgraphRequest Error: ${error.message}`);
     return subgraphError(res, `subgraphRequest Error: ${error.message}`);
   }
-
-  if (result?.data && caching) {
-    set(key, result).then(() => console.log('Cache stored', { key }));
-  }
-
-  return res.json(result);
 });
 
 export default router;

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,22 +1,37 @@
 import express from 'express';
 import { parse, print } from 'graphql';
-import { graphqlQuery, sha256 } from './utils';
+import { version } from '../package.json';
 import { get, set } from './aws';
+import { graphqlQuery, sha256, subgraphError } from './utils';
 
 const router = express.Router();
 
 let cached = 0;
 
 router.get('/', (req, res) => {
-  return res.json({ cached });
+  const commit = process.env.COMMIT_HASH || '';
+  const v = commit ? `${version}#${commit.substr(0, 7)}` : version;
+  res.json({
+    cached,
+    version: v
+  });
 });
 
 router.post('/*', async (req, res) => {
   let url = req.params[0];
+  const { query } = req.body;
+  if (!url) return subgraphError(res, 'No subgraph URL provided');
+  if (!query) return subgraphError(res, 'No query provided');
+
   url = url.startsWith('http') ? url : `https://${url}`;
 
-  const { query } = req.body;
-  const obj = parse(query);
+  let obj: undefined | any;
+  try {
+    obj = parse(query);
+  } catch (error: any) {
+    return subgraphError(res, `Query parse error: ${error.message}`);
+  }
+
   const str = print(obj);
   const key = sha256(`${url}:${str}`);
 
@@ -38,9 +53,18 @@ router.post('/*', async (req, res) => {
     }
   }
 
-  const result = await graphqlQuery(url, str);
+  let result;
+  try {
+    result = await graphqlQuery(url, str);
+    if (result.errors) {
+      return subgraphError(res, null, result.errors);
+    }
+  } catch (error: any) {
+    console.log(`subgraphRequest Error: ${error.message}`);
+    return subgraphError(res, `subgraphRequest Error: ${error.message}`);
+  }
 
-  if (caching) {
+  if (result?.data && caching) {
     set(key, result).then(() => console.log('Cache stored', { key }));
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
+import cors from 'cors';
 import 'dotenv/config';
 import express from 'express';
-import cors from 'cors';
 import api from './api';
 
 const app = express();

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,5 @@
-import { createHash } from 'crypto';
 import fetch from 'cross-fetch';
+import { createHash } from 'crypto';
 
 export function sha256(str) {
   return createHash('sha256').update(str).digest('hex');
@@ -14,5 +14,18 @@ export async function graphqlQuery(url: string, query) {
     },
     body: JSON.stringify({ query })
   });
-  return await res.json();
+  let responseData: any = await res.text();
+  try {
+    responseData = JSON.parse(responseData);
+  } catch (e) {
+    throw new Error(`Text response: ${responseData}`);
+  }
+  return responseData;
+}
+
+export function subgraphError(res, error: null | string = null, errors = []) {
+  if (error) return res.status(500).json({ errors: [{ message: error }] });
+  return res.status(500).json({
+    errors
+  });
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -23,9 +23,6 @@ export async function graphqlQuery(url: string, query) {
   return responseData;
 }
 
-export function subgraphError(res, error: null | string = null, errors = []) {
-  if (error) return res.status(500).json({ errors: [{ message: error }] });
-  return res.status(500).json({
-    errors
-  });
+export function subgraphError(res, error: null | string = null) {
+  return res.status(500).json({ errors: [{ message: error }] });
 }


### PR DESCRIPTION
Fixes in this PR:
- There is no error handling, whenever someone requests without `url` or `query`, then the server was crashing
- We are caching the response even if the subgraph returns an error, which is wrong and can cause many issue
- Sometimes subgraphs return a text response in case of error.
- Return version and commit hash on `/api` route like all other APIs



Admin tasks for @bonustrack 
- [ ] Once merged, Add a "App-level ENV varaible' where `key` is `COMMIT_HASH` and `value` is `${_self.COMMIT_HASH}`