### PR TITLE
Add try-catch to request deduplicator

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -41,14 +41,16 @@ router.post('/*', async (req, res) => {
     queryObj.definitions[0].selectionSet.selections.every(selection =>
       selection.arguments.some(argument => argument.name.value === 'block')
     );
-
-  const result: any = await serve(key, getData, [url, query, key, caching]);
-  if (result.errors) {
-    console.log(result.errors);
-    return res.status(500).json(result);
+  try {
+    const result: any = await serve(key, getData, [url, query, key, caching]);
+    if (result.errors) {
+      console.log(result.errors);
+      return res.status(500).json(result);
+    }
+    return res.json(result);
+  } catch (error: any) {
+    return subgraphError(res, error.message || 'Unknown error');
   }
-
-  return res.json(result);
 });
 
 const getData = async (url: string, query: string, key: string, caching: boolean) => {

--- a/src/helpers/requestDeduplicator.ts
+++ b/src/helpers/requestDeduplicator.ts
@@ -11,7 +11,7 @@ export default function serve(key, action, args) {
       .finally(() => {
         ongoingRequests.delete(key);
       });
-  
+
     ongoingRequests.set(key, requestPromise);
   }
 


### PR DESCRIPTION
I see error:
```bash
 ﻿[requestDeduplicator] request error FetchError: request to https://gateway.thegraph.com/api/<REDACTED>/deployments/id/QmXZiV6S13ha6QXq4dmaM3TB4CHcDxBMvGexSNu9Kc28EH failed, reason: socket hang up


2023-08-24 18:08:04.436 [subgrapher] [INFO] ﻿[UnhandledPromiseRejection: This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). The promise rejected with the reason "#<Object>".] {
```