### PR TITLE
chore: upgrade to node 18

### DIFF
--- a/.github/workflows/create-sentry-release.yml
+++ b/.github/workflows/create-sentry-release.yml
@@ -7,7 +7,11 @@ on:
 
 jobs:
   create-sentry-release:
+    strategy:
+      matrix:
+        target: ['18']
     uses: snapshot-labs/actions/.github/workflows/create-sentry-release.yml@main
     with:
       project: subgrapher
+      target: ${{ matrix.target }}
     secrets: inherit

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,5 +4,10 @@ on: [push]
 
 jobs:
   lint:
+    strategy:
+      matrix:
+        target: ['18']
     uses: snapshot-labs/actions/.github/workflows/lint.yml@main
     secrets: inherit
+    with:
+      target: ${{ matrix.target }}

--- a/package.json
+++ b/package.json
@@ -34,5 +34,8 @@
     "@types/node": "^18.11.6",
     "eslint": "^8.28.0",
     "prettier": "^2.8.0"
+  },
+  "engines": {
+    "node": "^18.0.0"
   }
 }


### PR DESCRIPTION
This PR upgrade the required node version to 18

- [x] Waiting for tests PR https://github.com/snapshot-labs/subgrapher/pull/19 before merging
- [x] Update DO config to support node 18