### PR TITLE
chore: capture graphql error

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -46,7 +46,7 @@ router.post('/*', async (req, res) => {
   try {
     const result: any = await serve(key, getData, [url, query, key, caching]);
     if (result.errors) {
-      capture(result);
+      capture(new Error('GraphQl error'), result.errors);
       return res.status(500).json(result);
     }
     return res.json(result);


### PR DESCRIPTION
- Fix sentry capture, which should take a `Error` object instead of JSON object.
- Send the `errors` details as context to sentry
