### PR TITLE
fix: improve error logging

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -47,14 +47,11 @@ router.post('/*', async (req, res) => {
     const result: any = await serve(key, getData, [url, query, key, caching]);
     if (result.errors) {
       capture(new Error('GraphQl error'), result.errors);
-      return res.status(400).json(result);
+      return subgraphError(res, result, 400);
     }
     return res.json(result);
   } catch (error: any) {
-    if (error.errors) {
-      return res.status(500).json(error);
-    }
-    return subgraphError(res, error.message || 'Unknown error');
+    return subgraphError(res, error);
   }
 });
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -32,7 +32,7 @@ export async function graphqlQuery(url: string, query) {
   return responseData;
 }
 
-export function subgraphError(res, error: any = null, code = 500) {
+export function subgraphError(res, error: any = 'Unknown error', code = 500) {
   return res.status(code).json(error?.errors ? error : { errors: [{ message: error }] });
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -32,8 +32,8 @@ export async function graphqlQuery(url: string, query) {
   return responseData;
 }
 
-export function subgraphError(res, error: null | string = null, code = 500) {
-  return res.status(code).json({ errors: [{ message: error }] });
+export function subgraphError(res, error: any = null, code = 500) {
+  return res.status(code).json(error?.errors ? error : { errors: [{ message: error }] });
 }
 
 const httpsAgent = new https.Agent({ keepAlive: true });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -21,8 +21,13 @@ export async function graphqlQuery(url: string, query) {
   try {
     responseData = JSON.parse(responseData);
   } catch (e) {
-    capture(e);
-    throw new Error(`Text response: ${responseData}`);
+    capture({ error: { code: res.status, message: res.statusText } }, { url });
+
+    if (!res.ok) {
+      throw new Error(`Unable to connect to ${url}, code: ${res.status}`);
+    } else {
+      throw new Error(`Text response: ${responseData}`);
+    }
   }
   return responseData;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -32,8 +32,8 @@ export async function graphqlQuery(url: string, query) {
   return responseData;
 }
 
-export function subgraphError(res, error: null | string = null) {
-  return res.status(500).json({ errors: [{ message: error }] });
+export function subgraphError(res, error: null | string = null, code = 500) {
+  return res.status(code).json({ errors: [{ message: error }] });
 }
 
 const httpsAgent = new https.Agent({ keepAlive: true });

--- a/test/e2e/index.test.ts
+++ b/test/e2e/index.test.ts
@@ -1,6 +1,8 @@
 import request from 'supertest';
 
 const HOST = `http://localhost:${process.env.PORT || 3003}`;
+const PROXIED_URL =
+  '/subgrapher.snapshot.org/api.thegraph.com/subgraphs/name/snapshot-labs/snapshot-arbitrum';
 
 describe('api', () => {
   describe('send a request to the proxied service', () => {
@@ -11,20 +13,16 @@ describe('api', () => {
 
     describe('on success', () => {
       it('should return a 200', async () => {
-        const response = await request(HOST)
-          .post(
-            '/gateway-arbitrum.network.thegraph.com/api/0f15b42bdeff7a063a4e1757d7e2f99e/subgraphs/id/4YgtogVaqoM8CErHWDK8mKQ825BcVdKB8vBYmb4avAQo'
-          )
-          .send(payload);
+        const response = await request(HOST).post(PROXIED_URL).send(payload);
 
         expect(response.statusCode).toBe(200);
         expect(response.body).toEqual({
           data: {
             delegations: [
               {
-                delegator: '0x00015f4a9b778a81cde7a9e6330bf0e2b46a882b',
+                delegator: '0x00000e36688330d643e7a7f25440320049a6c210',
                 space: '',
-                delegate: '0x59ee84e74662e824e44835322bf6078f4f93dd37'
+                delegate: '0x9abcaeae8ac01136740f83cb52bee3c8106c108f'
               }
             ]
           }
@@ -34,20 +32,27 @@ describe('api', () => {
 
     describe('on error', () => {
       it('should return a 400 on malformed query', async () => {
-        const response = await request(HOST).post(
-          '/gateway-arbitrum.network.thegraph.com/api/0f15b42bdeff7a063a4e1757d7e2f99e/subgraphs/id/4YgtogVaqoM8CErHWDK8mKQ825BcVdKB8vBYmb4avAQo'
-        );
+        const response = await request(HOST).post(PROXIED_URL);
 
-        expect(response.statusCode).toBe(500);
+        expect(response.statusCode).toBe(400);
         expect(response.body).toEqual({
           errors: [{ message: 'No query provided' }]
         });
       });
 
-      it('should return a 500 on invalid query', async () => {
+      it('should return a 400 on missing url', async () => {
+        const response = await request(HOST).post('/');
+
+        expect(response.statusCode).toBe(400);
+        expect(response.body).toEqual({
+          errors: [{ message: 'No subgraph URL provided' }]
+        });
+      });
+
+      it('should return a 400 on invalid query', async () => {
         const response = await request(HOST).post('/gateway-test').send({ query: 'sdkfksdf' });
 
-        expect(response.statusCode).toBe(500);
+        expect(response.statusCode).toBe(400);
         expect(response.body.errors[0].message).toContain('Query parse error');
       });
 
@@ -56,7 +61,39 @@ describe('api', () => {
 
         expect(response.statusCode).toBe(500);
         expect(response.body).toEqual({
-          errors: [{ message: 'Unknown error' }]
+          errors: [
+            {
+              message:
+                'request to https://gateway-test failed, reason: getaddrinfo ENOTFOUND gateway-test'
+            }
+          ]
+        });
+      });
+
+      it('should return a 500 on network error to proxied url', async () => {
+        const response = await request(HOST).post('/snapshot.org').send(payload);
+
+        expect(response.statusCode).toBe(500);
+        expect(response.body).toEqual({
+          errors: [
+            {
+              message: 'Unable to connect to https://snapshot.org, code: 405'
+            }
+          ]
+        });
+      });
+
+      it('should return a 400 on graphql error', async () => {
+        const response = await request(HOST).post(PROXIED_URL).send({
+          query:
+            'query { delegations (where: {space_in: ["", "stgdao.eth", "stgdao"]}, first: 1, skip: 1000000000) { delegator space delegate } }'
+        });
+
+        expect(response.statusCode).toBe(400);
+        expect(response.body).toEqual({
+          errors: [
+            { message: expect.stringContaining('The `skip` argument must be between 0 and') }
+          ]
         });
       });
     });


### PR DESCRIPTION
## 🧿 Current issues / What's wrong ?


Currently, when subgraph request is failing due to network error (timeout, etc...), it just log a `JSON.parse` error on Sentry, and return an error with the text response on the caller side.

See error example: https://snapshot-labs.sentry.io/issues/4493643081/?project=4505917750247424&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=30d&stream_index=0


## 💊 Fixes / Solution

Fix #22

Improve logging and error message when subgraph url is returning text message due to network error.


## 🚧 Changes

- When request is failing due to network error, log the network error on Sentry, which will be more useful than logging a `JSON.parse error`, which tell us nothing, since we try/catch a json.parse already.
- On caller side, also return a more meaningful error than an Error with just the request body content
- On user input error, return 400 error code
