### PR TITLE
fix: Handle delegation subgraphs and add error handling for invalid network

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -24,8 +24,11 @@ router.post('/*', async (req, res) => {
   let { query } = req.body;
   if (!url) return subgraphError(res, 'No subgraph URL provided', 400);
   if (!query) return subgraphError(res, 'No query provided', 400);
-
-  url = buildURL(url);
+  try {
+    url = buildURL(url);
+  } catch (error: any) {
+    return subgraphError(res, error.message, 400);
+  }
   let queryObj: any;
   try {
     queryObj = parse(query);

--- a/src/helpers/delegationSubgraphs.ts
+++ b/src/helpers/delegationSubgraphs.ts
@@ -3,16 +3,12 @@ const SUBGRAPH_KEY = process.env.SUBGRAPH_KEY;
 
 export default {
   '1': `https://gateway-arbitrum.network.thegraph.com/api/${SUBGRAPH_KEY}/subgraphs/id/4YgtogVaqoM8CErHWDK8mKQ825BcVdKB8vBYmb4avAQo`,
-  '5': 'https://subgrapher.snapshot.org/api.thegraph.com/subgraphs/name/snapshot-labs/snapshot-goerli',
-  '10': 'https://subgrapher.snapshot.org/api.thegraph.com/subgraphs/name/snapshot-labs/snapshot-optimism',
-  '56': 'https://subgrapher.snapshot.org/api.thegraph.com/subgraphs/name/snapshot-labs/snapshot-binance-smart-chain',
-  '100':
-    'https://subgrapher.snapshot.org/api.thegraph.com/subgraphs/name/snapshot-labs/snapshot-gnosis-chain',
-  '137':
-    'https://subgrapher.snapshot.org/api.thegraph.com/subgraphs/name/snapshot-labs/snapshot-polygon',
-  '250':
-    'https://subgrapher.snapshot.org/api.thegraph.com/subgraphs/name/snapshot-labs/snapshot-fantom',
-  '42161':
-    'https://subgrapher.snapshot.org/api.thegraph.com/subgraphs/name/snapshot-labs/snapshot-arbitrum',
-  '11155111': `https://subgrapher.snapshot.org/gateway-arbitrum.network.thegraph.com/api/${SUBGRAPH_KEY}/subgraphs/id/2SZVRR6G8txMFtf39aw2aP7BTAawRVwgqHeQXMhr7BRJ`
+  '5': 'https://api.thegraph.com/subgraphs/name/snapshot-labs/snapshot-goerli',
+  '10': 'https://api.thegraph.com/subgraphs/name/snapshot-labs/snapshot-optimism',
+  '56': 'https://api.thegraph.com/subgraphs/name/snapshot-labs/snapshot-binance-smart-chain',
+  '100': 'https://api.thegraph.com/subgraphs/name/snapshot-labs/snapshot-gnosis-chain',
+  '137': 'https://api.thegraph.com/subgraphs/name/snapshot-labs/snapshot-polygon',
+  '250': 'https://api.thegraph.com/subgraphs/name/snapshot-labs/snapshot-fantom',
+  '42161': 'https://api.thegraph.com/subgraphs/name/snapshot-labs/snapshot-arbitrum',
+  '11155111': `https://gateway-arbitrum.network.thegraph.com/api/${SUBGRAPH_KEY}/subgraphs/id/2SZVRR6G8txMFtf39aw2aP7BTAawRVwgqHeQXMhr7BRJ`
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -47,6 +47,7 @@ export function buildURL(url: string): string {
   if (url.startsWith('delegation')) {
     const network = url.split('/')[1];
     if (network && delegationSubgraphs[network]) return delegationSubgraphs[network];
+    if (network && !delegationSubgraphs[network]) throw new Error('Invalid network');
   }
   return `https://${url}`;
 }


### PR DESCRIPTION
### Summery: 
- Change delegation subgraph URLs, (it is sending requests to subgraph again)
- Error handle for invalid delegation network

### How to test:
```bash
curl --location 'http://localhost:3000/delegation/10' \
--data '{
  "query": "query { delegations (where: {space_in: [\"\", \"stgdao.eth\", \"stgdao\"]}, first: 1000, skip: 4000) { delegator space delegate } }"
}'
```
Should return empty array
```bash
curl --location 'http://localhost:3000/delegation/10000' \
--data '{
  "query": "query { delegations (where: {space_in: [\"\", \"stgdao.eth\", \"stgdao\"]}, first: 1000, skip: 4000) { delegator space delegate } }"
}'
```
Should return error 