### PR TITLE
Fix: Move to upgraded subgraphs

### DIFF
--- a/src/helpers/delegationSubgraphs.ts
+++ b/src/helpers/delegationSubgraphs.ts
@@ -3,12 +3,11 @@ const SUBGRAPH_KEY = process.env.SUBGRAPH_KEY;
 
 export default {
   '1': `https://gateway-arbitrum.network.thegraph.com/api/${SUBGRAPH_KEY}/subgraphs/id/4YgtogVaqoM8CErHWDK8mKQ825BcVdKB8vBYmb4avAQo`,
-  '5': 'https://api.thegraph.com/subgraphs/name/snapshot-labs/snapshot-goerli',
-  '10': 'https://api.thegraph.com/subgraphs/name/snapshot-labs/snapshot-optimism',
-  '56': 'https://api.thegraph.com/subgraphs/name/snapshot-labs/snapshot-binance-smart-chain',
-  '100': 'https://api.thegraph.com/subgraphs/name/snapshot-labs/snapshot-gnosis-chain',
-  '137': 'https://api.thegraph.com/subgraphs/name/snapshot-labs/snapshot-polygon',
-  '250': 'https://api.thegraph.com/subgraphs/name/snapshot-labs/snapshot-fantom',
-  '42161': 'https://api.thegraph.com/subgraphs/name/snapshot-labs/snapshot-arbitrum',
+  '10': `https://gateway-arbitrum.network.thegraph.com/api/${SUBGRAPH_KEY}/subgraphs/id/CAsVTyvLA6vnvDX9zgXifmi3wFM8GYeNHvRpxsABvbYL`,
+  '56': `https://gateway-arbitrum.network.thegraph.com/api/${SUBGRAPH_KEY}/subgraphs/id/GuTMtMnx7zukaA1hiHB1uz6FR45gpZX3GtiEN7Cyitjd`,
+  '100': `https://gateway-arbitrum.network.thegraph.com/api/${SUBGRAPH_KEY}/subgraphs/id/2XuuZyGrxw72keXKfeHQW7yaGqVa7dyoghkgdGMdC6Az`,
+  '137': `https://gateway-arbitrum.network.thegraph.com/api/${SUBGRAPH_KEY}/subgraphs/id/7ynRuH2PPw975dtHkthpZCyQGKBCrxFA8VsYD3KE631B`,
+  '250': `https://gateway-arbitrum.network.thegraph.com/api/${SUBGRAPH_KEY}/subgraphs/id/szZ3FWewDGHtpeZzf6uQ5dxPY68JNfrGPoWqBXwtBXR`,
+  '42161': `https://gateway-arbitrum.network.thegraph.com/api/${SUBGRAPH_KEY}/subgraphs/id/HuLBhuKuknXEEUmVmKR8Lsmpi5h1SfNLGcaa1e9tWyMG`,
   '11155111': `https://gateway-arbitrum.network.thegraph.com/api/${SUBGRAPH_KEY}/subgraphs/id/2SZVRR6G8txMFtf39aw2aP7BTAawRVwgqHeQXMhr7BRJ`
 };


### PR DESCRIPTION
- Move to new upgraded subgraphs https://thegraph.com/explorer/profile/0x8c28cf33d9fd3d0293f963b1cd27e3ff422b425c?view=Subgraphs&chain=arbitrum-one
- Remove goerli endpoint

How to test:
```bash
curl --location 'http://localhost:3000/delegation/100' \
--header 'accept: application/json' \
--header 'Content-Type: application/json' \
--data '{
    "query": "query { delegations (where: {space_in: [\"\", \"stgdao.eth\", \"stgdao\"]}, first: 1000, skip: 0) { delegator space delegate } }"
}'
```
Replace with other networks