### PR TITLE
fix: Hande variables

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -38,7 +38,10 @@ router.post('/*', async (req, res) => {
   }
 
   query = print(queryObj);
-  const key = sha256(`${url}:${query}:${JSON.stringify(variables)}`);
+  const key =
+    variables && Object.keys(variables).length > 0
+      ? sha256(`${url}:${query}:${JSON.stringify(variables)}`)
+      : sha256(`${url}:${query}`);
 
   // @ts-ignore
   const caching =

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -9,7 +9,7 @@ export function sha256(str) {
   return createHash('sha256').update(str).digest('hex');
 }
 
-export async function graphqlQuery(url: string, query) {
+export async function graphqlQuery(url: string, query, variables = {}) {
   const res = await fetchWithKeepAlive(url, {
     method: 'POST',
     headers: {
@@ -17,7 +17,7 @@ export async function graphqlQuery(url: string, query) {
       'Content-Type': 'application/json'
     },
     timeout: 30e3,
-    body: JSON.stringify({ query })
+    body: JSON.stringify({ query, variables })
   });
   let responseData: any = await res.text();
   try {


### PR DESCRIPTION
Previously we were ignoring `variables` passed into the body, now that we use other subgraphs, we need to pass variables as well

### How to test:
Pass variables to subgraphs
```bash
curl --location 'http://localhost:3000/subgraph/arbitrum/5XqPmWe6gjyrJtFn9cLy237i4cWw2j9HcUJEXsP5qGtH' \
--header 'accept: application/json, multipart/mixed' \
--header 'accept-language: en-US,en;q=0.9' \
--header 'content-type: application/json' \
--data '{"query":"query Domain($id: ID!) {\n  account(id: $id) {\n    domains {\n      name\n      expiryDate\n    }\n    wrappedDomains {\n      name\n      expiryDate\n    }\n  }\n  domains(block:{number: 20074255}){\n    id\n  }\n}","variables":{"id":"0x24f15402c6bb870554489b2fd2049a85d75b982f"}}'
```